### PR TITLE
Add convenience script to start a shell in the dev container.

### DIFF
--- a/script/shell
+++ b/script/shell
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+docker-compose run --rm app bash


### PR DESCRIPTION
This script is handy for tooling around in the dev container, i.e. to run the examples.