### PR TITLE
Update coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swp
 nohup.out
 incentive_config.yml
+coverage

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,10 +23,9 @@ GEM
       pry (>= 0.9.12)
       shellany (~> 0.0)
       thor (>= 0.18.1)
-    guard-compat (1.2.1)
-    guard-minitest (2.4.4)
-      guard-compat (~> 1.2)
-      minitest (>= 3.0)
+    guard-rake (1.0.0)
+      guard
+      rake
     guard-rubocop (1.2.0)
       guard (~> 2.0)
       rubocop (~> 0.20)
@@ -77,7 +76,7 @@ DEPENDENCIES
   byebug
   codeclimate-test-reporter
   guard
-  guard-minitest
+  guard-rake
   guard-rubocop
   minitest (~> 5.0)
   pry

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ DEPENDENCIES
   rake (~> 10.0)
   rubocop
   ruby_gntp
+  simplecov
   streamer!
 
 BUNDLED WITH

--- a/Guardfile
+++ b/Guardfile
@@ -1,7 +1,7 @@
 notification :off unless ENV['GNTP_NOTIFY']
 notification :gntp, host: '10.0.2.2', sticky: false if ENV['GNTP_NOTIFY']
 
-guard :minitest do
+guard :rake, task: :test do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { 'spec' }
   watch('spec/spec_helper.rb')  { 'spec' }

--- a/README.md
+++ b/README.md
@@ -47,12 +47,6 @@ $ script/init
 This will create the data container for gems at /usr/local/bundle used inside
 the app and guard containers.
 
-To start guard in the background:
-
-```bash
-$ script/guard
-```
-
 To start guard in the foreground, 
 
 ```bash

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,8 @@
-require 'guard'
+require 'rake/testtask'
 
-task :guards do
-  Guard.setup
-  Guard.state.session.plugins.all.each(&:run_all)
+Rake::TestTask.new do |t|
+  t.libs << 'spec'
+  t.pattern = 'spec/**/*.rb'
 end
 
-task default: :guards
+task default: :test

--- a/script/guard
+++ b/script/guard
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-docker-compose up -d guard

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,12 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-$LOAD_PATH.unshift File.expand_path('../support', __FILE__)
-
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
-require 'streamer'
+if ENV['GNTP_NOTIFY']
+  require 'simplecov'
+  SimpleCov.start
+else
+  require 'codeclimate-test-reporter'
+  CodeClimate::TestReporter.start
+end
 
 require 'minitest/autorun'
 require 'minitest/spec'
 require 'pry'
+require 'streamer'

--- a/streamer.gemspec
+++ b/streamer.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'ruby_gntp'
   spec.add_development_dependency 'guard-minitest'
   spec.add_development_dependency 'guard-rubocop'
+  spec.add_development_dependency 'simplecov'
 end

--- a/streamer.gemspec
+++ b/streamer.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'guard'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'ruby_gntp'
-  spec.add_development_dependency 'guard-minitest'
   spec.add_development_dependency 'guard-rubocop'
+  spec.add_development_dependency 'guard-rake'
   spec.add_development_dependency 'simplecov'
 end


### PR DESCRIPTION
removes guard-minitest, as this monkey-patched the guard notifier, and always used GNTP (as it was available). This broke the ability to have accurate simplecov test coverage metrics, as the process would end in guard before the tests were run.

I created a simple rake task to run minitest after having added the coverage requires and starts.

I also removed the background guard script, as it is useless when there are errors. Use `script/test`